### PR TITLE
Stateless connections with handle caching

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -191,6 +192,11 @@ func (c Config) validate() error {
 		err = fmt.Errorf("%s\n%s", err.Error(), "Please enter a tls key path")
 	}
 	return err
+}
+
+// IsSecurityEnabled returns true when the cluster security is enabled
+func (c *Config) IsSecurityEnabled() bool {
+	return strings.TrimSpace(string(c.ClusterPublicKeyFile)) != ""
 }
 
 // Check : check the configuration to test for basic security features

--- a/jwt/lib.go
+++ b/jwt/lib.go
@@ -24,7 +24,7 @@ type JSONWebToken struct {
 	SecretKey string
 }
 
-func unmarshalRSAKey(data string) (*rsa.PrivateKey, error) {
+func UnmarshalRSAKey(data string) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode([]byte(data))
 	if block == nil {
 		return nil, errors.New("Failed to decode PEM data")
@@ -43,13 +43,8 @@ func unmarshalRSAKey(data string) (*rsa.PrivateKey, error) {
 	return rsaKey, nil
 }
 
-func Build(rsaPrivateKey string, username string, secretKey string) (string, error) {
+func Build(key *rsa.PrivateKey, username string, secretKey string) (string, error) {
 	var token string
-
-	key, err := unmarshalRSAKey(rsaPrivateKey)
-	if err != nil {
-		return token, err
-	}
 
 	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: key}, (&jose.SignerOptions{}).WithType("JWT"))
 	if err != nil {
@@ -88,15 +83,10 @@ func Build(rsaPrivateKey string, username string, secretKey string) (string, err
 	return token, nil
 }
 
-func Parse(rsaPrivateKey string, rawToken string) (JSONWebToken, error) {
+func Parse(key *rsa.PrivateKey, rawToken string) (JSONWebToken, error) {
 	var token JSONWebToken
 	var claims jwt.Claims
 	var privateClaims privateClaims
-
-	key, err := unmarshalRSAKey(rsaPrivateKey)
-	if err != nil {
-		return token, err
-	}
 
 	encryptedToken, err := jwt.ParseSignedAndEncrypted(rawToken)
 	if err != nil {

--- a/jwt/lib_test.go
+++ b/jwt/lib_test.go
@@ -36,12 +36,17 @@ b9Ym/nxaqyTu0PxajXkKm5Q=
 -----END PRIVATE KEY-----`
 
 func TestJWT(t *testing.T) {
-	tokenString, err := jwt.Build(rsaPrivateKey, "mike", "pass")
+	key, err := jwt.UnmarshalRSAKey(rsaPrivateKey)
+	if err != nil {
+		t.Fatalf("Failed to parse RSA private key: %s", err.Error())
+	}
+
+	tokenString, err := jwt.Build(key, "mike", "pass")
 	if err != nil {
 		t.Fatalf("Failed to generate token: %s", err.Error())
 	}
 
-	token, err := jwt.Parse(rsaPrivateKey, tokenString)
+	token, err := jwt.Parse(key, tokenString)
 	if err != nil {
 		t.Fatalf("Failed to parse token %s: %s", tokenString, err.Error())
 	}


### PR DESCRIPTION
- Switch to go-jose from go-jwt for encryption support
- add username and secret key to jwt as private claims
- use tls key to encrypt token or default embedded private key in insecure mode
- cache handles and create new handle from jwt as fall back